### PR TITLE
Add pryrc overrides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
+gem "tabulo"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,40 @@
+PATH
+  remote: .
+  specs:
+    appdev_support (0.2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.0)
+    rake (12.3.3)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    tabulo (2.8.2)
+      tty-screen (= 0.8.1)
+      unicode-display_width (~> 2.2)
+    tty-screen (0.8.1)
+    unicode-display_width (2.4.2)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  appdev_support!
+  rake (~> 12.0)
+  rspec (~> 3.0)
+  tabulo
+
+BUNDLED WITH
+   2.2.3

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ You can call `.at` on an `ActiveRecord:Relation` instead of just `[]` to mirror 
 Events.all.at(0)
 ```
 
+If the containing app has `pry` or `pry-rails` installed, the `print` functionality has been enhanced:
+- `ActiveRecord::Relation` objects are displayed like this
+  ```irb
+  Todo.all
+  => Todo::ActiveRecord_Relation (array with 1 Todo instance inside)
+  ```
+
 ## Configuration
 
 Add an initializer:
@@ -73,7 +80,8 @@ Add an initializer:
 
 AppdevSupport.config do |config|
 # config.action_dispatch = true;
-# config.active_record = true;
+# config.active_record   = true;
+# config.pryrc           = true;
 end
 AppdevSupport.init
 ```

--- a/appdev_support.gemspec
+++ b/appdev_support.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.add_runtime_dependency(%q<tabulo>.freeze, [">= 0"])
 end

--- a/lib/appdev_support.rb
+++ b/lib/appdev_support.rb
@@ -4,7 +4,7 @@ module AppdevSupport
   class Error < StandardError; end
 
   class << self
-    attr_writer :active_record, :action_dispatch
+    attr_writer :active_record, :action_dispatch, :pryrc
 
     def action_dispatch
       @action_dispatch || true
@@ -12,6 +12,10 @@ module AppdevSupport
 
     def active_record
       @active_record || true
+    end
+
+    def pryrc
+      @pryrc || true
     end
 
     def config
@@ -30,6 +34,9 @@ module AppdevSupport
       load "appdev_support/action_dispatch/request/session/store.rb"
       load "appdev_support/action_dispatch/cookies/cookie_jar/fetch.rb"
       load "appdev_support/action_dispatch/cookies/cookie_jar/store.rb"
+    end
+    if @pryrc
+      load "appdev_support/pryrc.rb" if Object.const_defined?("Pry")
     end
   end
 end

--- a/lib/appdev_support/pryrc.rb
+++ b/lib/appdev_support/pryrc.rb
@@ -1,0 +1,43 @@
+require "tabulo"
+Pry.config.print = proc do |output, value, _pry_|
+  case value
+  when ActiveRecord::Relation
+    row_count = value.count
+
+    max_rows_to_display_at_once = 5
+    num_rows_to_frame_with = 2
+    
+    column_names = value.column_names.map(&:to_sym) - [:created_at, :updated_at]
+    
+    header_frequency = 10
+    border_style = :markdown
+
+    table_options = { header_frequency: header_frequency, border: border_style }
+
+    if row_count > max_rows_to_display_at_once
+      output.puts Tabulo::Table.new(value.limit(num_rows_to_frame_with), *column_names, table_options).pack
+
+      output.puts
+      output.puts "(... #{row_count - 2*num_rows_to_frame_with} more rows between ...)"
+      output.puts
+
+      output.puts Tabulo::Table.new(value.offset(row_count - num_rows_to_frame_with).limit(num_rows_to_frame_with), *column_names, table_options).pack
+    else
+      output.puts Tabulo::Table.new(value, *column_names, table_options).pack
+    end
+
+    output.puts
+    output.puts "=> #{value.to_s}"
+    output.puts
+  when Class
+    Pry::ColorPrinter.default(output, value, _pry_)
+
+    output.puts
+    output.puts("The #{value} class itself.")
+  else
+    Pry::ColorPrinter.default(output, value, _pry_)
+    
+    output.puts
+    output.puts("An instance of the #{value.class} class.")
+  end
+end


### PR DESCRIPTION
## Problem

Another Phase I / AD1 patch we do is with `.pryrc` file. Instead of having to add `.pryrc` to every project and make sure it's up to date, we can save the configuration in this gem and enable or disable the feature in the initializer like other patches.

## Questions

The basic override that we used before is  still possible

but while looking through old issues there is a more enhanced version that might be better

![image](https://user-images.githubusercontent.com/17581658/235202127-3150b6c0-c7ba-4499-82e9-d91cdfc035da.png)
